### PR TITLE
Include countries.geojson File in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include countries.geojson
 include s2mgrs/data/points.csv
-include s2mgrs/data/tiles.csv
 include s2mgrs/data/s2mgrs_s2_index.geojson
+include s2mgrs/data/tiles.csv


### PR DESCRIPTION
### Description

When running pip install, all metadata files are included in installed package except the countries.geojson. I am adding here in manifest file to test if this could be the reason of exemption.

### Test

Testing